### PR TITLE
Add menu entry for embit EMB-RasPi-130x-Cape

### DIFF
--- a/chirpstack/luci-app-chirpstack-concentratord/htdocs/luci-static/resources/view/chirpstack/concentratord.js
+++ b/chirpstack/luci-app-chirpstack-concentratord/htdocs/luci-static/resources/view/chirpstack/concentratord.js
@@ -172,6 +172,15 @@ return view.extend({
                                 usb: false,
                             },
                         },
+                        {
+                            id: "emb_raspi_130x_cape_lr1302",
+                            name: "Embit - EMB-RasPI-130x-Cape with LR1302",
+                            supportedRegions: ["EU868"],
+                            defaultFlags: {
+                                gnss: false,
+                                usb: false,
+                            },
+                        },
                     ]
                 },
                 {

--- a/chirpstack/luci-app-chirpstack-concentratord/htdocs/luci-static/resources/view/chirpstack/concentratord.js
+++ b/chirpstack/luci-app-chirpstack-concentratord/htdocs/luci-static/resources/view/chirpstack/concentratord.js
@@ -83,6 +83,15 @@ return view.extend({
                             },
                         },
                         {
+                            id: "embit_emb_lr1302_mpcie",
+                            name: "Embit - EMB-LR1302-mPCIe",
+                            supportedRegions: ["AU915", "EU868", "IN865", "KR920", "RU864", "US915"],
+                            defaultFlags: {
+                                gnss: false,
+                                usb: false,
+                            },
+                        },
+                        {
                             id: "rak_2287",
                             name: "RAK - RAK2287",
                             supportedRegions: ["AS923", "AS923_2", "AS923_3", "AS923_4", "AU915", "CN470", "EU433", "EU868", "IN865", "KR920", "RU864", "US915"],
@@ -166,15 +175,6 @@ return view.extend({
                         {
                             id: "waveshare_sx1302_lorawan_gateway_hat",
                             name: "Waveshare - SX1302 LoRaWAN Gateway HAT",
-                            supportedRegions: ["EU868"],
-                            defaultFlags: {
-                                gnss: false,
-                                usb: false,
-                            },
-                        },
-                        {
-                            id: "emb_raspi_130x_cape_lr1302",
-                            name: "Embit - EMB-RasPI-130x-Cape with LR1302",
                             supportedRegions: ["EU868"],
                             defaultFlags: {
                                 gnss: false,


### PR DESCRIPTION
Add menu entry for the EMB-RasPi-130x Cape with an EMB-1302 concentrator card installed.
See this PR for required changes in chirpstack-concentratord: https://github.com/chirpstack/chirpstack-concentratord/pull/112

Tested and working with chirpstack gateway os on a Raspberry Pi Zero W.