### PR TITLE
Add SPI device paths to RAK7391 concentratord selector

### DIFF
--- a/chirpstack/luci-app-chirpstack-concentratord-target-rak7391/htdocs/luci-static/resources/view/chirpstack/concentratord-slot1.js
+++ b/chirpstack/luci-app-chirpstack-concentratord-target-rak7391/htdocs/luci-static/resources/view/chirpstack/concentratord-slot1.js
@@ -21,6 +21,7 @@ return view.extend({
                         },
                     ],
                     com_dev_paths: [
+                        { path: "/dev/spidev0.0", usb: false },
                         { path: "/dev/ttyACM0", usb: true },
                         { path: "/dev/ttyACM1", usb: true },
                     ],

--- a/chirpstack/luci-app-chirpstack-concentratord-target-rak7391/htdocs/luci-static/resources/view/chirpstack/concentratord-slot2.js
+++ b/chirpstack/luci-app-chirpstack-concentratord-target-rak7391/htdocs/luci-static/resources/view/chirpstack/concentratord-slot2.js
@@ -21,6 +21,7 @@ return view.extend({
                         },
                     ],
                     com_dev_paths: [
+                        { path: "/dev/spidev0.1", usb: false },
                         { path: "/dev/ttyACM0", usb: true },
                         { path: "/dev/ttyACM1", usb: true },
                     ],


### PR DESCRIPTION
Adds the available SPI device paths to the "Comm. device path" option in the concentratord UI for the RAK7391.