### PR TITLE
Add script to read and return Gateway ID from multiple slots

### DIFF
--- a/chirpstack/chirpstack-concentratord/Makefile
+++ b/chirpstack/chirpstack-concentratord/Makefile
@@ -77,6 +77,7 @@ define Package/chirpstack-concentratord/install
 
 	$(INSTALL_DIR) $(1)/usr/bin/
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/bin/gateway-id $(1)/usr/bin/
+	$(INSTALL_BIN) ./files/gateway-id.sh $(1)/usr/bin
 endef
 
 define Package/chirpstack-concentratord-2g4/install

--- a/chirpstack/chirpstack-concentratord/files/gateway-id.sh
+++ b/chirpstack/chirpstack-concentratord/files/gateway-id.sh
@@ -26,6 +26,6 @@ done
 
 IFS=$oldIFS
 
-[ "$OUTPUT" = "" ] && OUTPUT="could not read gateway_id"
+[ "$OUTPUT" = "" ] && OUTPUT="Could not read Gateway ID"
 
 echo "$OUTPUT"

--- a/chirpstack/chirpstack-concentratord/files/gateway-id.sh
+++ b/chirpstack/chirpstack-concentratord/files/gateway-id.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+SLOTS="|slot1|slot2"
+OUTPUT=""
+
+oldIFS=$IFS
+IFS="|"
+
+for SLOT in $SLOTS; do
+    
+    URL="/tmp/concentratord_command"
+    if [ "$SLOT" != "" ]; then
+        URL="/tmp/concentratord_${SLOT}_command"
+    fi
+
+    if [ -e "$URL" ]; then
+        GATEWAY_ID=$( /usr/bin/gateway-id -c "ipc://$URL" )
+        if [ $? -eq 0 ]; then
+            [ "$OUTPUT" != "" ] && OUTPUT="$OUTPUT / "
+            OUTPUT="${OUTPUT}${GATEWAY_ID}"
+            [ "$SLOT" != "" ] && OUTPUT="${OUTPUT} ($SLOT)"
+        fi
+    fi
+
+done
+
+IFS=$oldIFS
+
+[ "$OUTPUT" = "" ] && OUTPUT="could not read gateway_id"
+
+echo "$OUTPUT"

--- a/theme/luci-theme-argon/luasrc/view/themes/argon/footer.htm
+++ b/theme/luci-theme-argon/luasrc/view/themes/argon/footer.htm
@@ -17,7 +17,7 @@
 -%>
 
 <%
-	local handle = io.popen("/usr/bin/gateway-id")
+	local handle = io.popen("sh /usr/bin/gateway-id.sh")
 	local gateway_id = handle:read("*a")                                                                                      
 	handle:close()
 -%>


### PR DESCRIPTION
Adds a wrapper script around gateway-id to retrieve and show the ID for all enabled concentrators.

This can serve as a double purpose: 
- feedback on the UI about the concentrator started properly
- get the Gateway EUI for a dual band gateway registered on the LNS as two different gateways

This PR removes the requirement for the symlinks to slot1 pipes so another PR is required on the main chirpstack-gateway-os repo.