### PR TITLE
Add reset GPIOs for SPI concentrators in RAK7391 and RAK7289v2

### DIFF
--- a/chirpstack/chirpstack-concentratord-target-rak7289v2/files/chirpstack-concentratord-slot1.config
+++ b/chirpstack/chirpstack-concentratord-target-rak7289v2/files/chirpstack-concentratord-slot1.config
@@ -13,6 +13,7 @@ config sx1302
     option command_bind     'ipc:///tmp/concentratord_slot1_command'
     option com_dev_path     '/dev/ttyACM0'
     option gnss_dev_path    'gpsd://localhost:2947'
+    option sx1302_reset_pin '11'
 
 config 2g4
     option model            'rak_5148'

--- a/chirpstack/chirpstack-concentratord-target-rak7391/files/chirpstack-concentratord-slot1.config
+++ b/chirpstack/chirpstack-concentratord-target-rak7391/files/chirpstack-concentratord-slot1.config
@@ -12,6 +12,7 @@ config sx1302
     option event_bind       'ipc:///tmp/concentratord_slot1_event'
     option command_bind     'ipc:///tmp/concentratord_slot1_command'
     option com_dev_path      '/dev/ttyACM0'
+    option sx1302_reset_pin '17'
 
 config 2g4
     option model            'rak_5148'

--- a/chirpstack/chirpstack-concentratord-target-rak7391/files/chirpstack-concentratord-slot2.config
+++ b/chirpstack/chirpstack-concentratord-target-rak7391/files/chirpstack-concentratord-slot2.config
@@ -12,6 +12,7 @@ config sx1302
     option event_bind       'ipc:///tmp/concentratord_slot2_event'
     option command_bind     'ipc:///tmp/concentratord_slot2_command'
     option com_dev_path      '/dev/ttyACM1'
+    option sx1302_reset_pin '6'
 
 config 2g4
     option model            'rak_5148'


### PR DESCRIPTION
Adding GPIOs to reset SPI concentrator in RAK7391 and RAK7289v2 gateways