### PR TITLE
chirpstack: add gateway-id support from uci for sx1302

### DIFF
--- a/chirpstack/chirpstack-concentratord/files/chirpstack-concentratord.sh
+++ b/chirpstack/chirpstack-concentratord/files/chirpstack-concentratord.sh
@@ -82,7 +82,7 @@ conf_rule_sx1301() {
 conf_rule_sx1302() {
 	local cfg="$1"
 	local config_name="$2"
-	local model region channel_plan gnss usb
+	local model region channel_plan gnss usb gateway_id
 	local model_flags antenna_gain
 	local sx1302_reset_pin com_dev_path i2c_dev_path
 	local event_bind command_bind
@@ -93,6 +93,7 @@ conf_rule_sx1302() {
 	config_get channel_plan $cfg channel_plan
 	config_get gnss $cfg gnss
 	config_get usb $cfg usb
+	config_get gateway_id $cfg gateway_id
 
 	config_get event_bind $cfg event_bind
 	config_get command_bind $cfg command_bind
@@ -138,6 +139,7 @@ conf_rule_sx1302() {
 			region="$region"
 			model_flags=[$model_flags]
 			antenna_gain=$antenna_gain
+			gateway_id="$gateway_id"
 	EOF
 
 	if [ "$sx1302_reset_pin" != "" ]; then

--- a/chirpstack/chirpstack-concentratord/files/chirpstack-concentratord.sh
+++ b/chirpstack/chirpstack-concentratord/files/chirpstack-concentratord.sh
@@ -139,8 +139,11 @@ conf_rule_sx1302() {
 			region="$region"
 			model_flags=[$model_flags]
 			antenna_gain=$antenna_gain
-			gateway_id="$gateway_id"
 	EOF
+
+	if [ "$gateway_id" != "" ]; then
+	   	echo "gateway_id=\"$gateway_id\"" >> /var/etc/$config_name/concentratord.toml
+	fi
 
 	if [ "$sx1302_reset_pin" != "" ]; then
 		echo "sx1302_reset_pin=$sx1302_reset_pin" >> /var/etc/$config_name/concentratord.toml


### PR DESCRIPTION
The gateway_id in uci config for concentratord it's ignored by config builder.

The objective is made possible to configure gateway_id from user config.

I don't know if other methods already exists, but it work for sx1301 and I used the same method

Linked with #10