### PR TITLE
Feat uci mqtt forwarder add commands and metadata

### DIFF
--- a/chirpstack/chirpstack-mqtt-forwarder/files/chirpstack-mqtt-forwarder.sh
+++ b/chirpstack/chirpstack-mqtt-forwarder/files/chirpstack-mqtt-forwarder.sh
@@ -18,6 +18,8 @@ configure() {
 	config_foreach conf_rule_concentratord "concentratord" "$config_name"
 	config_foreach conf_rule_mqtt "mqtt" "$config_name"
 	config_foreach conf_rule_filters "filters" "$config_name"
+
+	conf_rule_commands "$config_name"
 }
 
 conf_rule_concentratord() {
@@ -139,4 +141,25 @@ conf_rule_join_eui_prefix() {
 	cat >> /var/etc/$config_name/chirpstack-mqtt-forwarder.toml <<- EOF
 		"$1",
 	EOF
+}
+
+conf_rule_commands() {
+	local config_name="$1"
+
+	cat >> /var/etc/$config_name/chirpstack-mqtt-forwarder.toml <<- EOF
+		[commands]
+	EOF
+
+	config_foreach conf_command "commands" "$config_name"
+}
+
+conf_command() {
+        local cfg="$1"
+        local config_name="$2"
+
+        local command
+
+        config_get command $cfg command
+
+        echo "$cfg=$command" >> /var/etc/$config_name/chirpstack-mqtt-forwarder.toml
 }

--- a/chirpstack/chirpstack-mqtt-forwarder/files/chirpstack-mqtt-forwarder.sh
+++ b/chirpstack/chirpstack-mqtt-forwarder/files/chirpstack-mqtt-forwarder.sh
@@ -1,5 +1,10 @@
 . /lib/functions.sh
 
+# check if is valid toml array
+toml_array_validator() {
+	[[ '^(\[\s*(("([^\"\\]|\\"|\\\\)*")(\s*,\s*("([^\"\\]|\\"|\\\\)*"))*)?\s*\])$' =~ "$1" ]]
+}
+
 configure() {
 	local config_name="$1"
 
@@ -202,6 +207,7 @@ conf_metadata_static() {
 	local static
 
 	config_get static $cfg static
+
 	if [ "$static" != "" ]; then
 		echo "$cfg=$static" >> /var/etc/$config_name/chirpstack-mqtt-forwarder.toml
 	fi
@@ -224,7 +230,8 @@ conf_rule_commands() {
 }
 
 # Foreach config 'type' 'key'
-# Find option command and generate key=value
+# Find option command and generate key=array
+# example datetime=["date", "-R"]
 conf_command() {
 	local cfg="$1"
 	local config_name="$2"
@@ -233,7 +240,7 @@ conf_command() {
 
 	config_get command $cfg command
 
-	if [ "$command" != "" ]; then
+	if toml_array_validator "$command"; then
 		echo "$cfg=$command" >> /var/etc/$config_name/chirpstack-mqtt-forwarder.toml
 	fi
 }

--- a/chirpstack/chirpstack-mqtt-forwarder/files/chirpstack-mqtt-forwarder.sh
+++ b/chirpstack/chirpstack-mqtt-forwarder/files/chirpstack-mqtt-forwarder.sh
@@ -19,8 +19,8 @@ configure() {
   config_foreach conf_rule_mqtt "mqtt" "$config_name"
   config_foreach conf_rule_filters "filters" "$config_name"
 
-  conf_rule_metadata "$config_name"
   conf_rule_commands "$config_name"
+  conf_rule_metadata "$config_name"
 }
 
 conf_rule_concentratord() {
@@ -154,10 +154,6 @@ conf_rule_metadata() {
   local config_name="$1"
 
   cat >>/var/etc/$config_name/chirpstack-mqtt-forwarder.toml <<-EOF
-		[metadata]
-	EOF
-
-  cat >>/var/etc/$config_name/chirpstack-mqtt-forwarder.toml <<-EOF
 		[metadata.static]
 	EOF
 
@@ -182,7 +178,7 @@ conf_metadata_static() {
   config_get static $cfg static
 
   if [ "$static" != "" ]; then
-    echo "$cfg=$static" >>/var/etc/$config_name/chirpstack-mqtt-forwarder.toml
+    echo "$cfg=\"$static\"" >>/var/etc/$config_name/chirpstack-mqtt-forwarder.toml
   fi
 }
 

--- a/chirpstack/chirpstack-mqtt-forwarder/files/chirpstack-mqtt-forwarder.sh
+++ b/chirpstack/chirpstack-mqtt-forwarder/files/chirpstack-mqtt-forwarder.sh
@@ -24,8 +24,8 @@ configure() {
 	config_foreach conf_rule_mqtt "mqtt" "$config_name"
 	config_foreach conf_rule_filters "filters" "$config_name"
 
-	conf_rule_commands "$config_name"
 	conf_rule_metadata "$config_name"
+	conf_rule_commands "$config_name"
 }
 
 conf_rule_concentratord() {

--- a/chirpstack/chirpstack-mqtt-forwarder/files/chirpstack-mqtt-forwarder.sh
+++ b/chirpstack/chirpstack-mqtt-forwarder/files/chirpstack-mqtt-forwarder.sh
@@ -149,27 +149,6 @@ conf_rule_join_eui_prefix() {
 	EOF
 }
 
-conf_rule_commands() {
-	local config_name="$1"
-
-	cat >> /var/etc/$config_name/chirpstack-mqtt-forwarder.toml <<- EOF
-		[commands]
-	EOF
-
-	config_foreach conf_command "commands" "$config_name"
-}
-
-conf_command() {
-	local cfg="$1"
-	local config_name="$2"
-
-	local command
-
-	config_get command $cfg command
-
-	echo "$cfg=$command" >> /var/etc/$config_name/chirpstack-mqtt-forwarder.toml
-}
-
 # Convert uci config metadata to chirpstack-mqtt-forwarder.toml
 # config metadata 'datetime'
 #		 option command 'datetime=["date", "-R"]'

--- a/chirpstack/chirpstack-mqtt-forwarder/files/chirpstack-mqtt-forwarder.sh
+++ b/chirpstack/chirpstack-mqtt-forwarder/files/chirpstack-mqtt-forwarder.sh
@@ -1,10 +1,10 @@
 . /lib/functions.sh
 
 configure() {
-    local config_name="$1"
+	local config_name="$1"
 
-    mkdir -p /var/etc/$config_name
-    echo "" > /var/etc/$config_name/chirpstack-mqtt-forwarder.toml
+	mkdir -p /var/etc/$config_name
+	echo "" > /var/etc/$config_name/chirpstack-mqtt-forwarder.toml
 
 	cat >> /var/etc/$config_name/chirpstack-mqtt-forwarder.toml <<- EOF
 		[logging]
@@ -46,7 +46,7 @@ conf_rule_concentratord() {
 
 conf_rule_mqtt() {
 	local cfg="$1"
-    local config_name="$2"
+	local config_name="$2"
 	local topic_prefix json server username password qos clean_session client_id ca_cert tls_cert tls_key
 
 	config_get topic_prefix $cfg topic_prefix
@@ -106,7 +106,7 @@ conf_rule_mqtt() {
 
 conf_rule_filters() {
 	local cfg="$1"
-    local config_name="$2"
+	local config_name="$2"
 
 	cat >> /var/etc/$config_name/chirpstack-mqtt-forwarder.toml <<- EOF
 		[backend.filters]
@@ -131,14 +131,14 @@ conf_rule_filters() {
 }
 
 conf_rule_dev_addr_prefix() {
-    local config_name="$2"
+	local config_name="$2"
 	cat >> /var/etc/$config_name/chirpstack-mqtt-forwarder.toml <<- EOF
 		"$1",
 	EOF
 }
 
 conf_rule_join_eui_prefix() {
-    local config_name="$2"
+	local config_name="$2"
 	cat >> /var/etc/$config_name/chirpstack-mqtt-forwarder.toml <<- EOF
 		"$1",
 	EOF
@@ -155,22 +155,22 @@ conf_rule_commands() {
 }
 
 conf_command() {
-        local cfg="$1"
-        local config_name="$2"
+	local cfg="$1"
+	local config_name="$2"
 
-        local command
+	local command
 
-        config_get command $cfg command
+	config_get command $cfg command
 
-        echo "$cfg=$command" >> /var/etc/$config_name/chirpstack-mqtt-forwarder.toml
+	echo "$cfg=$command" >> /var/etc/$config_name/chirpstack-mqtt-forwarder.toml
 }
 
 # Convert uci config metadata to chirpstack-mqtt-forwarder.toml
 # config metadata 'datetime'
-#         option command 'datetime=["date", "-R"]'
+#		 option command 'datetime=["date", "-R"]'
 #
 # config metadata 'serial_number'
-#         option static '1234'
+#		 option static '1234'
 conf_rule_metadata() {
 	local config_name="$1"
 
@@ -196,23 +196,23 @@ conf_rule_metadata() {
 # Foreach config 'type' 'key'
 # Find option static and generate key=value
 conf_metadata_static() {
-        local cfg="$1"
-        local config_name="$2"
+	local cfg="$1"
+	local config_name="$2"
 
-        local static
+	local static
 
-        config_get static $cfg static
-		if [ "$static" != "" ]; then
-        	echo "$cfg=$static" >> /var/etc/$config_name/chirpstack-mqtt-forwarder.toml
-		fi
+	config_get static $cfg static
+	if [ "$static" != "" ]; then
+		echo "$cfg=$static" >> /var/etc/$config_name/chirpstack-mqtt-forwarder.toml
+	fi
 }
 
 # Convert uci config commands to chirpstack-mqtt-forwarder.toml
 # config commands 'reboot'
-#         option command '["/usr/bin/reboot"]'
+#		 option command '["/usr/bin/reboot"]'
 #
 # config commands 'shutdown'
-#         option command '["/usr/bin/shutdown"]'
+#		 option command '["/usr/bin/shutdown"]'
 conf_rule_commands() {
 	local config_name="$1"
 
@@ -226,14 +226,14 @@ conf_rule_commands() {
 # Foreach config 'type' 'key'
 # Find option command and generate key=value
 conf_command() {
-        local cfg="$1"
-        local config_name="$2"
+	local cfg="$1"
+	local config_name="$2"
 
-        local command
+	local command
 
-        config_get command $cfg command
+	config_get command $cfg command
 
-        if [ "$command" != "" ]; then
-			echo "$cfg=$command" >> /var/etc/$config_name/chirpstack-mqtt-forwarder.toml
-		fi
+	if [ "$command" != "" ]; then
+		echo "$cfg=$command" >> /var/etc/$config_name/chirpstack-mqtt-forwarder.toml
+	fi
 }

--- a/chirpstack/chirpstack-mqtt-forwarder/files/chirpstack-mqtt-forwarder.sh
+++ b/chirpstack/chirpstack-mqtt-forwarder/files/chirpstack-mqtt-forwarder.sh
@@ -1,12 +1,12 @@
 . /lib/functions.sh
 
 configure() {
-	local config_name="$1"
+  local config_name="$1"
 
-	mkdir -p /var/etc/$config_name
-	echo "" > /var/etc/$config_name/chirpstack-mqtt-forwarder.toml
+  mkdir -p /var/etc/$config_name
+  echo "" >/var/etc/$config_name/chirpstack-mqtt-forwarder.toml
 
-	cat >> /var/etc/$config_name/chirpstack-mqtt-forwarder.toml <<- EOF
+  cat >>/var/etc/$config_name/chirpstack-mqtt-forwarder.toml <<-EOF
 		[logging]
 			log_to_syslog=true
 		
@@ -14,81 +14,81 @@ configure() {
 			enabled="concentratord"
 	EOF
 
-	config_load "$config_name"
-	config_foreach conf_rule_concentratord "concentratord" "$config_name"
-	config_foreach conf_rule_mqtt "mqtt" "$config_name"
-	config_foreach conf_rule_filters "filters" "$config_name"
+  config_load "$config_name"
+  config_foreach conf_rule_concentratord "concentratord" "$config_name"
+  config_foreach conf_rule_mqtt "mqtt" "$config_name"
+  config_foreach conf_rule_filters "filters" "$config_name"
 
-	conf_rule_metadata "$config_name"
-	conf_rule_commands "$config_name"
+  conf_rule_metadata "$config_name"
+  conf_rule_commands "$config_name"
 }
 
 conf_rule_concentratord() {
-	local cfg="$1"
-	local config_name="$2"
-	local event_url command_url
+  local cfg="$1"
+  local config_name="$2"
+  local event_url command_url
 
-	config_get event_url $cfg event_url
-	config_get command_url $cfg command_url
+  config_get event_url $cfg event_url
+  config_get command_url $cfg command_url
 
-	cat >> /var/etc/$config_name/chirpstack-mqtt-forwarder.toml <<- EOF
+  cat >>/var/etc/$config_name/chirpstack-mqtt-forwarder.toml <<-EOF
 		[backend.concentratord]
 	EOF
 
-	if [ "$event_url" != "" ]; then
-		echo "event_url=\"$event_url\"" >> /var/etc/$config_name/chirpstack-mqtt-forwarder.toml
-	fi
+  if [ "$event_url" != "" ]; then
+    echo "event_url=\"$event_url\"" >>/var/etc/$config_name/chirpstack-mqtt-forwarder.toml
+  fi
 
-	if [ "$command_url" != "" ]; then
-		echo "command_url=\"$command_url\"" >> /var/etc/$config_name/chirpstack-mqtt-forwarder.toml
-	fi
+  if [ "$command_url" != "" ]; then
+    echo "command_url=\"$command_url\"" >>/var/etc/$config_name/chirpstack-mqtt-forwarder.toml
+  fi
 }
 
 conf_rule_mqtt() {
-	local cfg="$1"
-	local config_name="$2"
-	local topic_prefix json server username password qos clean_session client_id ca_cert tls_cert tls_key
+  local cfg="$1"
+  local config_name="$2"
+  local topic_prefix json server username password qos clean_session client_id ca_cert tls_cert tls_key
 
-	config_get topic_prefix $cfg topic_prefix
-	config_get json $cfg json
-	config_get server $cfg server
-	config_get username $cfg username
-	config_get password $cfg password
-	config_get qos $cfg qos
-	config_get_bool clean_session $cfg clean_session
-	config_get client_id $cfg client_id
-	config_get ca_cert $cfg ca_cert
-	config_get tls_cert $cfg tls_cert
-	config_get tls_key $cfg tls_key
+  config_get topic_prefix $cfg topic_prefix
+  config_get json $cfg json
+  config_get server $cfg server
+  config_get username $cfg username
+  config_get password $cfg password
+  config_get qos $cfg qos
+  config_get_bool clean_session $cfg clean_session
+  config_get client_id $cfg client_id
+  config_get ca_cert $cfg ca_cert
+  config_get tls_cert $cfg tls_cert
+  config_get tls_key $cfg tls_key
 
-	if [ "$json" = "1" ]; then
-		json="true"
-	else
-		json="false"
-	fi
+  if [ "$json" = "1" ]; then
+    json="true"
+  else
+    json="false"
+  fi
 
-	if [ "$clean_session" = "1" ]; then
-		clean_session="true"
-	else
-		clean_session="false"
-	fi
+  if [ "$clean_session" = "1" ]; then
+    clean_session="true"
+  else
+    clean_session="false"
+  fi
 
-	if [ "$ca_cert" != "" ]; then
-		echo "$ca_cert" > /var/etc/$config_name/ca.pem
-		ca_cert="/var/etc/$config_name/ca.pem"
-	fi
+  if [ "$ca_cert" != "" ]; then
+    echo "$ca_cert" >/var/etc/$config_name/ca.pem
+    ca_cert="/var/etc/$config_name/ca.pem"
+  fi
 
-	if [ "$tls_cert" != "" ]; then
-		echo "$tls_cert" > /var/etc/$config_name/cert.pem
-		tls_cert="/var/etc/$config_name/cert.pem"
-	fi
+  if [ "$tls_cert" != "" ]; then
+    echo "$tls_cert" >/var/etc/$config_name/cert.pem
+    tls_cert="/var/etc/$config_name/cert.pem"
+  fi
 
-	if [ "$tls_key" != "" ]; then
-		echo "$tls_key" > /var/etc/$config_name/key.pem
-		tls_key="/var/etc/$config_name/key.pem"
-	fi
+  if [ "$tls_key" != "" ]; then
+    echo "$tls_key" >/var/etc/$config_name/key.pem
+    tls_key="/var/etc/$config_name/key.pem"
+  fi
 
-	cat >> /var/etc/$config_name/chirpstack-mqtt-forwarder.toml <<- EOF
+  cat >>/var/etc/$config_name/chirpstack-mqtt-forwarder.toml <<-EOF
 		[mqtt]
 			topic_prefix="$topic_prefix"
 			json=$json
@@ -105,41 +105,41 @@ conf_rule_mqtt() {
 }
 
 conf_rule_filters() {
-	local cfg="$1"
-	local config_name="$2"
+  local cfg="$1"
+  local config_name="$2"
 
-	cat >> /var/etc/$config_name/chirpstack-mqtt-forwarder.toml <<- EOF
+  cat >>/var/etc/$config_name/chirpstack-mqtt-forwarder.toml <<-EOF
 		[backend.filters]
 			dev_addr_prefixes=[
 	EOF
 
-	config_list_foreach $cfg dev_addr_prefix conf_rule_dev_addr_prefix "$config_name"
+  config_list_foreach $cfg dev_addr_prefix conf_rule_dev_addr_prefix "$config_name"
 
-	cat >> /var/etc/$config_name/chirpstack-mqtt-forwarder.toml <<- EOF
+  cat >>/var/etc/$config_name/chirpstack-mqtt-forwarder.toml <<-EOF
 		]
 	EOF
 
-	cat >> /var/etc/$config_name/chirpstack-mqtt-forwarder.toml <<- EOF
+  cat >>/var/etc/$config_name/chirpstack-mqtt-forwarder.toml <<-EOF
 			join_eui_prefixes=[
 	EOF
 
-	config_list_foreach $cfg join_eui_prefix conf_rule_join_eui_prefix "$config_name"
+  config_list_foreach $cfg join_eui_prefix conf_rule_join_eui_prefix "$config_name"
 
-	cat >> /var/etc/$config_name/chirpstack-mqtt-forwarder.toml <<- EOF
+  cat >>/var/etc/$config_name/chirpstack-mqtt-forwarder.toml <<-EOF
 		]
 	EOF
 }
 
 conf_rule_dev_addr_prefix() {
-	local config_name="$2"
-	cat >> /var/etc/$config_name/chirpstack-mqtt-forwarder.toml <<- EOF
+  local config_name="$2"
+  cat >>/var/etc/$config_name/chirpstack-mqtt-forwarder.toml <<-EOF
 		"$1",
 	EOF
 }
 
 conf_rule_join_eui_prefix() {
-	local config_name="$2"
-	cat >> /var/etc/$config_name/chirpstack-mqtt-forwarder.toml <<- EOF
+  local config_name="$2"
+  cat >>/var/etc/$config_name/chirpstack-mqtt-forwarder.toml <<-EOF
 		"$1",
 	EOF
 }
@@ -151,40 +151,39 @@ conf_rule_join_eui_prefix() {
 # config metadata 'serial_number'
 #		 option static '1234'
 conf_rule_metadata() {
-	local config_name="$1"
+  local config_name="$1"
 
-	cat >> /var/etc/$config_name/chirpstack-mqtt-forwarder.toml <<- EOF
+  cat >>/var/etc/$config_name/chirpstack-mqtt-forwarder.toml <<-EOF
 		[metadata]
 	EOF
 
-	cat >> /var/etc/$config_name/chirpstack-mqtt-forwarder.toml <<- EOF
+  cat >>/var/etc/$config_name/chirpstack-mqtt-forwarder.toml <<-EOF
 		[metadata.static]
 	EOF
 
-	config_foreach conf_metadata_static "metadata" "$config_name"
+  config_foreach conf_metadata_static "metadata" "$config_name"
 
-
-	cat >> /var/etc/$config_name/chirpstack-mqtt-forwarder.toml <<- EOF
+  cat >>/var/etc/$config_name/chirpstack-mqtt-forwarder.toml <<-EOF
 		[metadata.commands]
 	EOF
 
-	config_foreach conf_command "metadata" "$config_name"
+  config_foreach conf_command "metadata" "$config_name"
 
 }
 
 # Foreach config 'type' 'key'
 # Find option static and generate key=value
 conf_metadata_static() {
-	local cfg="$1"
-	local config_name="$2"
+  local cfg="$1"
+  local config_name="$2"
 
-	local static
+  local static
 
-	config_get static $cfg static
+  config_get static $cfg static
 
-	if [ "$static" != "" ]; then
-		echo "$cfg=$static" >> /var/etc/$config_name/chirpstack-mqtt-forwarder.toml
-	fi
+  if [ "$static" != "" ]; then
+    echo "$cfg=$static" >>/var/etc/$config_name/chirpstack-mqtt-forwarder.toml
+  fi
 }
 
 # Convert uci config commands to chirpstack-mqtt-forwarder.toml
@@ -194,13 +193,13 @@ conf_metadata_static() {
 # config commands 'shutdown'
 #		 option command '["/usr/bin/shutdown"]'
 conf_rule_commands() {
-	local config_name="$1"
+  local config_name="$1"
 
-	cat >> /var/etc/$config_name/chirpstack-mqtt-forwarder.toml <<- EOF
+  cat >>/var/etc/$config_name/chirpstack-mqtt-forwarder.toml <<-EOF
 		[commands]
 	EOF
 
-	config_foreach conf_command "commands" "$config_name"
+  config_foreach conf_command "commands" "$config_name"
 }
 
 # Foreach config 'type' 'key'
@@ -210,26 +209,26 @@ conf_rule_commands() {
 # Find option command and generate key=array
 # example datetime=["date", "-R"]
 conf_command() {
-	local cfg="$1"
-	local config_name="$2"
+  local cfg="$1"
+  local config_name="$2"
 
-	local len
+  local len
 
-	# return number of option 'command' in $cfg if option is empty return nothing
-	config_get len $cfg command_LENGTH
+  # return number of option 'command' in $cfg if option is empty return nothing
+  config_get len $cfg command_LENGTH
 
-	[ -z "$len" ] && return 0
+  [ -z "$len" ] && return 0
 
-	echo -n "$cfg=[" >> /var/etc/$config_name/chirpstack-mqtt-forwarder.toml
+  echo -n "$cfg=[" >>/var/etc/$config_name/chirpstack-mqtt-forwarder.toml
 
-	# foreach list command 'value'
-	config_list_foreach $cfg command conf_command_arg "$config_name"
+  # foreach list command 'value'
+  config_list_foreach $cfg command conf_command_arg "$config_name"
 
-	echo "]" >> /var/etc/$config_name/chirpstack-mqtt-forwarder.toml
+  echo "]" >>/var/etc/$config_name/chirpstack-mqtt-forwarder.toml
 }
 
 conf_command_arg() {
-	local config_name="$2"
+  local config_name="$2"
 
-	echo -n "\"$1\"", >> /var/etc/$config_name/chirpstack-mqtt-forwarder.toml
+  echo -n "\"$1\"", >>/var/etc/$config_name/chirpstack-mqtt-forwarder.toml
 }

--- a/chirpstack/luci-app-chirpstack-mqtt-forwarder/htdocs/luci-static/resources/chirpstack-mqtt-forwarder.js
+++ b/chirpstack/luci-app-chirpstack-mqtt-forwarder/htdocs/luci-static/resources/chirpstack-mqtt-forwarder.js
@@ -4,102 +4,115 @@
 'require uci';
 
 return baseclass.extend({
-    /*
-        This renders the ChirpStack MQTT Forwarder configuration form
-        using the provided options.
-    */
-    renderForm: function (mqttForwarderConfig) {
-        var m, s, o, ro, as;
+  /*
+      This renders the ChirpStack MQTT Forwarder configuration form
+      using the provided options.
+  */
+  renderForm: function(mqttForwarderConfig) {
+    var m, s, o, ro, as;
 
-        m = new form.Map(mqttForwarderConfig, _('ChirpStack MQTT Forwarder'), _('ChirpStack MQTT Forwarder forwards data received by the ChirpStack Concentratord to a MQTT broker.'));
-        m.tabbed = true;
+    m = new form.Map(mqttForwarderConfig, _('ChirpStack MQTT Forwarder'), _('ChirpStack MQTT Forwarder forwards data received by the ChirpStack Concentratord to a MQTT broker.'));
+    m.tabbed = true;
 
-        s = m.section(form.TypedSection, 'global', _('Global configuration'));
-        s.anonymous = true;
+    s = m.section(form.TypedSection, 'global', _('Global configuration'));
+    s.anonymous = true;
 
-        // Is enabled
-        s.option(form.Flag, 'enabled', _('Enabled'), _('Enable ChirpStack MQTT Forwarder'));
+    // Is enabled
+    s.option(form.Flag, 'enabled', _('Enabled'), _('Enable ChirpStack MQTT Forwarder'));
 
 
-        s = m.section(form.TypedSection, 'mqtt', _('MQTT configuration'));
-        s.anonymous = true;
+    s = m.section(form.TypedSection, 'mqtt', _('MQTT configuration'));
+    s.anonymous = true;
 
-        // topic prefix
-        o = s.option(form.Value, 'topic_prefix', _('Topic prefix'), _('Specify the topic you want to use (e.g. \'eu868\'), without trailing slash.'));
-        o.optional = true;
-        o.validate = function (section_id, value) {
-            if (value.match(/^[a-zA-Z0-9\_\-\/\$]*$/)) {
-                return true;
-            }
+    // topic prefix
+    o = s.option(form.Value, 'topic_prefix', _('Topic prefix'), _('Specify the topic you want to use (e.g. \'eu868\'), without trailing slash.'));
+    o.optional = true;
+    o.validate = function(section_id, value) {
+      if (value.match(/^[a-zA-Z0-9\_\-\/\$]*$/)) {
+        return true;
+      }
 
-            return "Enter a valid MQTT prefix.";
-        };
+      return "Enter a valid MQTT prefix.";
+    };
 
-        // json encoding
-        s.option(form.Flag, 'json', _('Use JSON'), _('Use JSON encoding instead of Protobuf (binary). Use this only for debugging purposes.'));
+    // json encoding
+    s.option(form.Flag, 'json', _('Use JSON'), _('Use JSON encoding instead of Protobuf (binary). Use this only for debugging purposes.'));
 
-        // server
-        o = s.option(form.Value, 'server', _('Server'), _('MQTT server (e.g. scheme://host:port where scheme is tcp, ssl, ws, wss).'));
-        o.validate = function (section_id, value) {
-            if (value.match(/^(tcp|ssl|ws|wss):\/\/[\w\.\-]+:[\d]+$/)) {
-                return true;
-            }
+    // server
+    o = s.option(form.Value, 'server', _('Server'), _('MQTT server (e.g. scheme://host:port where scheme is tcp, ssl, ws, wss).'));
+    o.validate = function(section_id, value) {
+      if (value.match(/^(tcp|ssl|ws|wss):\/\/[\w\.\-]+:[\d]+$/)) {
+        return true;
+      }
 
-            return "Enter a valid MQTT server address.";
-        };
+      return "Enter a valid MQTT server address.";
+    };
 
-        // username
-        o = s.option(form.Value, 'username', _('Username'), _('Connect with the given username.'));
-        o.optional = true;
+    // username
+    o = s.option(form.Value, 'username', _('Username'), _('Connect with the given username.'));
+    o.optional = true;
 
-        // password
-        o = s.option(form.Value, 'password', _('Password'), _('Connect with the given password.'))
-        o.optional = true;
-        o.password = true;
+    // password
+    o = s.option(form.Value, 'password', _('Password'), _('Connect with the given password.'))
+    o.optional = true;
+    o.password = true;
 
-        // ca certificate
-        o = s.option(form.TextValue, 'ca_cert', _('CA certificate'));
-        o.optional = true;
-        o.cols = 80;
+    // ca certificate
+    o = s.option(form.TextValue, 'ca_cert', _('CA certificate'));
+    o.optional = true;
+    o.cols = 80;
 
-        // tls cert
-        o = s.option(form.TextValue, 'tls_cert', _('TLS certificate'));
-        o.optional = true;
-        o.cols = 80;
+    // tls cert
+    o = s.option(form.TextValue, 'tls_cert', _('TLS certificate'));
+    o.optional = true;
+    o.cols = 80;
 
-        o = s.option(form.TextValue, 'tls_key', _('TLS key-file'));
-        o.optional = true;
-        o.cols = 80;
+    o = s.option(form.TextValue, 'tls_key', _('TLS key-file'));
+    o.optional = true;
+    o.cols = 80;
 
-        // QoS
-        o = s.option(form.ListValue, 'qos', _('QoS'), _('Note: an increase of this value will decrease the performance.'));
-        o.value(0, 0);
-        o.value(1, 1);
-        o.value(2, 2);
+    // QoS
+    o = s.option(form.ListValue, 'qos', _('QoS'), _('Note: an increase of this value will decrease the performance.'));
+    o.value(0, 0);
+    o.value(1, 1);
+    o.value(2, 2);
 
-        // clean session
-        s.option(form.Flag, 'clean_session', _('Clean session'), _('By setting this flag you are indicating that no messages saved by the broker for this client should be delivered.'));
+    // clean session
+    s.option(form.Flag, 'clean_session', _('Clean session'), _('By setting this flag you are indicating that no messages saved by the broker for this client should be delivered.'));
 
-        // client id
-        o = s.option(form.Value, 'client_id', _('Client ID'), _('A client id must be no longer than 23 characters. If left blank, a random id will be generated by ChirpStack.'));
-        o.optional = true;
-        o.validate = function (section_id, value) {
-            if (value.match(/^[a-zA-Z0-9]{0,23}$/)) {
-                return true;
-            }
+    // client id
+    o = s.option(form.Value, 'client_id', _('Client ID'), _('A client id must be no longer than 23 characters. If left blank, a random id will be generated by ChirpStack.'));
+    o.optional = true;
+    o.validate = function(section_id, value) {
+      if (value.match(/^[a-zA-Z0-9]{0,23}$/)) {
+        return true;
+      }
 
-            return "Enter a valid Client ID";
-        };
+      return "Enter a valid Client ID";
+    };
 
-        s = m.section(form.TypedSection, 'filters', _('Filter configuration'));
-        s.anonymous = true;
+    s = m.section(form.TypedSection, 'filters', _('Filter configuration'));
+    s.anonymous = true;
 
-        // DevAddr prefixs
-        o = s.option(form.DynamicList, 'dev_addr_prefix', _('DevAddr prefixes'), _('Filter uplinks based on the configured DevAddr prefixes (e.g. \'0000ff00/24\'). If no filters have been configured, filtering is disabled.'));
+    // DevAddr prefixs
+    o = s.option(form.DynamicList, 'dev_addr_prefix', _('DevAddr prefixes'), _('Filter uplinks based on the configured DevAddr prefixes (e.g. \'0000ff00/24\'). If no filters have been configured, filtering is disabled.'));
 
-        // DevEUI prefixes
-        o = s.option(form.DynamicList, 'join_eui_prefix', _('JoinEUI prefixes'), _('Filter join-requests based on the configured JoinEUI prefixes (e.g. \'0000ff0000000000/24\'). If no filters have been configured, filtering is disabled.'))
+    // DevEUI prefixes
+    o = s.option(form.DynamicList, 'join_eui_prefix', _('JoinEUI prefixes'), _('Filter join-requests based on the configured JoinEUI prefixes (e.g. \'0000ff0000000000/24\'). If no filters have been configured, filtering is disabled.'))
 
-        return m.render();
-    },
+    // Commands
+    s = m.section(form.TypedSection, 'commands', _('Commands'));
+    s.addremove = true;
+
+    s.option(form.DynamicList, 'command', _('Command + arguments'), _('The first item must contain the path to the binary, the other items must be used to pass arguments (one item per argument).'));
+
+    // Metadata
+    s = m.section(form.TypedSection, 'metadata', _('Metadata'));
+    s.addremove = true;
+
+    s.option(form.Value, 'static', _('Static value'), _('Enter a static value -OR- enter a command below.'));
+    s.option(form.DynamicList, 'command', _('Command + arguments'), _('Configure this if no static value is configured. The first item must contain the path to the binary, the other items must be used to pass arguments (one item per argument).'));
+
+    return m.render();
+  },
 });


### PR DESCRIPTION
Implemente `Commands` and `Metadata` of `chirpstack-mqtt-forwarder` with UCI in `chirpstack-mqtt-forwarder.sh` for openWrt init.d service.

UCI config file

```uci
config commands 'reboot'
	option command '["/usr/bin/reboot"]'

config commands 'shutdown'
	option command '["/usr/bin/shutdown"]'

config metadata 'datetime'
	option command '["date", "-R"]'

config metadata 'serial_number'
	option static '1234'
```

generate

```yaml
[metadata]
[metadata.static]
serial_number=1234
[metadata.commands]
datetime=["date", "-R"]
[commands]
reboot=["/usr/bin/reboot"]
shutdown=["/usr/bin/shutdown"]
```

