### PR TITLE
Chirpstack Gateway OS 'Full' - Adding UCI commands for configuring the MQTT integration 

### DIFF
--- a/chirpstack/chirpstack/files/chirpstack.config
+++ b/chirpstack/chirpstack/files/chirpstack.config
@@ -1,2 +1,14 @@
 config network
     option net_id '000000'
+
+config integration_mqtt 'integration_mqtt'
+    option event_topic "application/{{application_id}}/device/{{dev_eui}}/event/{{event}}"
+    option command_topic "application/{{application_id}}/device/{{dev_eui}}/command/{{command}}"
+    option json "true"
+    option server "tcp://127.0.0.1:1883/"
+    option username ""
+    option password ""
+    option qos "0"
+    option clean_session "false"
+    option client_id ""
+    option keep_alive_interval "30s"

--- a/chirpstack/chirpstack/files/chirpstack.init
+++ b/chirpstack/chirpstack/files/chirpstack.init
@@ -27,6 +27,37 @@ config_rule_network_enabled_regions() {
 	cp /etc/$PACKAGE_NAME/region_$region.toml /var/etc/$PACKAGE_NAME
 }
 
+conf_rule_integration_mqtt() {
+	local cfg="$1"
+	local event_topic command_topic json server username password qos clean_session client_id keep_alive_interval
+
+	config_get event_topic "$cfg" event_topic
+	config_get command_topic "$cfg" command_topic
+	config_get json "$cfg" json
+	config_get server "$cfg" server
+	config_get username "$cfg" username
+	config_get password "$cfg" password
+	config_get qos "$cfg" qos
+	config_get clean_session "$cfg" clean_session
+	config_get client_id "$cfg" client_id
+	config_get keep_alive_interval "$cfg" keep_alive_interval
+
+	cat >> /var/etc/$PACKAGE_NAME/$PACKAGE_NAME.toml <<- EOF
+
+		[integration.mqtt]
+		event_topic="${event_topic}"
+		command_topic="${command_topic}"
+		json=${json}
+		server="${server}"
+		username="${username}"
+		password="${password}"
+		qos=${qos}
+		clean_session=${clean_session}
+		client_id="${client_id}"
+		keep_alive_interval="${keep_alive_interval}"
+EOF
+}
+
 configuration() {
 	mkdir -p /var/etc/$PACKAGE_NAME
 	rm -rf /var/etc/$PACKAGE_NAME/*.toml
@@ -43,14 +74,11 @@ configuration() {
 		enabled = [
 				"mqtt",
 		]
-
-		[integration.mqtt]
-		json=true
-		server="tcp://127.0.0.1:1883/"
-	EOF
+EOF
 
 	config_load "$PACKAGE_NAME"
 	config_foreach conf_rule_network "network"
+	config_foreach conf_rule_integration_mqtt "integration_mqtt"
 }
 
 start_service() {


### PR DESCRIPTION
Updates the chirpstack.config file to include UCI commands for the [integration.mqtt] section of the chirpstack.toml, then update the chirpstack.init to use these UCI commands when generating the runtime chirpstack.toml.

I left the tls_certificate options out as there is no easy way to upload them. The updates leave MQTT as the only enabled integration.