### PR TITLE
Remove redundant locked

### DIFF
--- a/chirpstack/chirpstack-concentratord/Makefile
+++ b/chirpstack/chirpstack-concentratord/Makefile
@@ -116,10 +116,10 @@ define Build/Prepare
 endef
 
 define Build/Compile
-	$(call Build/Compile/Cargo,chirpstack-concentratord-sx1301,--locked)
-	$(call Build/Compile/Cargo,chirpstack-concentratord-sx1302,--locked)
-	$(call Build/Compile/Cargo,chirpstack-concentratord-2g4,--locked)
-	$(call Build/Compile/Cargo,gateway-id,--locked)
+	$(call Build/Compile/Cargo,chirpstack-concentratord-sx1301)
+	$(call Build/Compile/Cargo,chirpstack-concentratord-sx1302)
+	$(call Build/Compile/Cargo,chirpstack-concentratord-2g4)
+	$(call Build/Compile/Cargo,gateway-id)
 endef
 
 $(eval $(call RustBinPackage,chirpstack-concentratord))

--- a/chirpstack/chirpstack-gateway-mesh/Makefile
+++ b/chirpstack/chirpstack-gateway-mesh/Makefile
@@ -52,7 +52,7 @@ define Package/chirpstack-gateway-mesh/install
 endef
 
 define Build/Compile
-	$(call Build/Compile/Cargo,.,--locked)
+	$(call Build/Compile/Cargo,.)
 endef
 
 $(eval $(call RustBinPackage,chirpstack-gateway-mesh))

--- a/chirpstack/chirpstack-mqtt-forwarder/Makefile
+++ b/chirpstack/chirpstack-mqtt-forwarder/Makefile
@@ -50,7 +50,7 @@ define Build/Prepare
 endef
 
 define Build/Compile
-	$(call Build/Compile/Cargo,.,--locked)
+	$(call Build/Compile/Cargo,.)
 endef
 
 $(eval $(call RustBinPackage,chirpstack-mqtt-forwarder))

--- a/chirpstack/chirpstack-udp-forwarder/Makefile
+++ b/chirpstack/chirpstack-udp-forwarder/Makefile
@@ -43,7 +43,7 @@ define Package/chirpstack-udp-forwarder/install
 endef
 
 define Build/Compile
-	$(call Build/Compile/Cargo,.,--locked)
+	$(call Build/Compile/Cargo,.)
 endef
 
 $(eval $(call RustBinPackage,chirpstack-udp-forwarder))

--- a/chirpstack/chirpstack/Makefile
+++ b/chirpstack/chirpstack/Makefile
@@ -74,7 +74,7 @@ define Build/Compile
 		yarn add @chirpstack/chirpstack-api-grpc-web@$(PKG_VERSION) && \
 		yarn build \
 	)
-	$(call Build/Compile/Cargo,chirpstack,--locked --no-default-features --features sqlite)
+	$(call Build/Compile/Cargo,chirpstack --no-default-features --features sqlite)
 endef
 
 $(eval $(call RustBinPackage,chirpstack))


### PR DESCRIPTION
Trying to fix an Rust issue by updating to the latest packages I ran into this issue.
> error: the argument '--locked' cannot be used multiple times