### PR TITLE
Allow to select ttyACM2 for LoRa module

### DIFF
--- a/chirpstack/luci-app-chirpstack-concentratord-target-rak7391/htdocs/luci-static/resources/view/chirpstack/concentratord-slot1.js
+++ b/chirpstack/luci-app-chirpstack-concentratord-target-rak7391/htdocs/luci-static/resources/view/chirpstack/concentratord-slot1.js
@@ -24,6 +24,7 @@ return view.extend({
                         { path: "/dev/spidev0.0", usb: false },
                         { path: "/dev/ttyACM0", usb: true },
                         { path: "/dev/ttyACM1", usb: true },
+                        { path: "/dev/ttyACM2", usb: true },
                     ],
                 },
                 {
@@ -40,6 +41,7 @@ return view.extend({
                     com_dev_paths: [
                         { path: "/dev/ttyACM0", usb: true },
                         { path: "/dev/ttyACM1", usb: true },
+                        { path: "/dev/ttyACM2", usb: true },
                     ],
                 }
             ],

--- a/chirpstack/luci-app-chirpstack-concentratord-target-rak7391/htdocs/luci-static/resources/view/chirpstack/concentratord-slot2.js
+++ b/chirpstack/luci-app-chirpstack-concentratord-target-rak7391/htdocs/luci-static/resources/view/chirpstack/concentratord-slot2.js
@@ -24,6 +24,7 @@ return view.extend({
                         { path: "/dev/spidev0.1", usb: false },
                         { path: "/dev/ttyACM0", usb: true },
                         { path: "/dev/ttyACM1", usb: true },
+                        { path: "/dev/ttyACM2", usb: true },
                     ],
                 },
                 {
@@ -40,6 +41,7 @@ return view.extend({
                     com_dev_paths: [
                         { path: "/dev/ttyACM0", usb: true },
                         { path: "/dev/ttyACM1", usb: true },
+                        { path: "/dev/ttyACM2", usb: true },
                     ],
                 }
             ],


### PR DESCRIPTION
Show `/dev/ttyACM2` as a possible devpath for concentratord in RAK7391. 
This is required when there is another ACM module on the board, such as the Miromico's Edge Card that exposes two ACM ports using, sometimes, `/dev/ttyACM0` and `/dev/ttyACM1` and moving the LoRa module to `/dev/ttyACM2`.
